### PR TITLE
fixed loading the developer-overlay if the xib is in another bundle

### DIFF
--- a/Classes/TBODeveloperOverlayKVDebugger/TBODeveloperOverlayKVDebuggerDetailViewController.m
+++ b/Classes/TBODeveloperOverlayKVDebugger/TBODeveloperOverlayKVDebuggerDetailViewController.m
@@ -37,7 +37,7 @@ typedef enum {
 @implementation TBODeveloperOverlayKVDebuggerDetailViewController
 
 - (instancetype)initWithDatasource:(id<TBODeveloperOverlayKVDebuggerDatasourceProtocol>)datasource andIndexPath:(NSIndexPath *)indexPath {
-    self = [super init];
+    self = [super initWithNibName:@"TBODeveloperOverlayKVDebuggerDetailViewController" bundle:[NSBundle bundleForClass:self.class]];
     if (self) {
         self.indexPath = indexPath;
         self.datasource = datasource;

--- a/Classes/TBODeveloperOverlayLogger/TBODeveloperOverlayLogger.m
+++ b/Classes/TBODeveloperOverlayLogger/TBODeveloperOverlayLogger.m
@@ -27,24 +27,21 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (instancetype)init {
-    self = [super init];
+- (instancetype)initWithDatasource:(id<TBODeveloperOverlayLoggerDatasourceProtocol>)datasource {
+    self = [self initWithNibName:@"TBODeveloperOverlayLogger" bundle:[NSBundle bundleForClass:self.class]];
     if (self) {
-        self.maxDisplayedCharacters = 50000;
-        self.edgesForExtendedLayout = UIRectEdgeNone;
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
+        self.datasource = datasource;
+        [self performSetup];
     }
     return self;
 }
 
-- (instancetype)initWithDatasource:(id<TBODeveloperOverlayLoggerDatasourceProtocol>)datasource {
-    self = [self init];
-    if (self) {
-        self.datasource = datasource;
-    }
-    return self;
+- (void)performSetup {
+    self.maxDisplayedCharacters = 50000;
+    self.edgesForExtendedLayout = UIRectEdgeNone;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
 }
 
 - (void)viewDidLoad {


### PR DESCRIPTION
Issue: When using the Developer Overlay in another app the Logger Overlay will be invisible
Reason: The xib of the overlay is not in [NSBundle mainBundle]
Fix: Initializing the ViewController with a specific Xib-Name and Bundle
