### PR TITLE
#10 Bugfix/number textfield allows character

### DIFF
--- a/Classes/TBODeveloperOverlayKVDebugger/TBODeveloperOverlayKVDebuggerDetailViewController.m
+++ b/Classes/TBODeveloperOverlayKVDebugger/TBODeveloperOverlayKVDebuggerDetailViewController.m
@@ -126,7 +126,7 @@ typedef enum {
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     NSCharacterSet *numbersOnly = [NSCharacterSet characterSetWithCharactersInString:@"0123456789.,"];
-    NSCharacterSet *characterSetFromTextField = [NSCharacterSet characterSetWithCharactersInString:textField.text];
+    NSCharacterSet *characterSetFromTextField = [NSCharacterSet characterSetWithCharactersInString:string];
     
     BOOL stringIsValid = [numbersOnly isSupersetOfSet:characterSetFromTextField];
     return stringIsValid;

--- a/Classes/TBODeveloperOverlayKVDebugger/TBODeveloperOverlayKVDebuggerDetailViewController.xib
+++ b/Classes/TBODeveloperOverlayKVDebugger/TBODeveloperOverlayKVDebuggerDetailViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -51,7 +51,7 @@
                         <textField hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AFM-6v-dYO">
                             <rect key="frame" x="20" y="63" width="560" height="30"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                            <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                             <connections>
                                 <outlet property="delegate" destination="-1" id="XIv-rh-3nZ"/>
                             </connections>


### PR DESCRIPTION
- Set the textfield to use the decimal keypad instead of the numbers keypad.
- Check if the new character is in the allowed characterset instead of the text already in the textfield.
